### PR TITLE
Fix swirl background persistence

### DIFF
--- a/assets/js/swirl.js
+++ b/assets/js/swirl.js
@@ -14,8 +14,9 @@
   const particles = Array.from({ length: 400 }, () => ({ x: Math.random() * w, y: Math.random() * h }));
 
   function animate() {
-    ctx.fillStyle = 'rgba(0,0,0,0.05)';
-    ctx.fillRect(0, 0, w, h);
+    // Clear with transparency instead of a dark overlay so the
+    // underlying page shows through.
+    ctx.clearRect(0, 0, w, h);
 
     ctx.fillStyle = '#fff';
     particles.forEach(p => {


### PR DESCRIPTION
## Summary
- clear the swirl canvas each frame so the page background shows through

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846c71a3bf48321b2fc48590158dcc5