### PR TITLE
Enhance fonts and add interactive widgets

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>{{ page.title | default: site.title }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 </head>
 <body>
@@ -24,5 +27,6 @@
   <!-- 5) Swirl scripts -->
   <script src="https://unpkg.com/simplex-noise@2.4.0/simplex-noise.js"></script>
   <script src="{{ '/assets/js/swirl.js' | relative_url }}"></script>
+  <script src="{{ '/assets/js/widgets.js' | relative_url }}"></script>
 </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -6,7 +6,7 @@ html, body {
   /* Allow the animated canvas to show through */
   background: transparent;
   color: #fff;
-  font-family: sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 
 /* 2) Canvas: full-screen, at the very back */
@@ -64,4 +64,30 @@ footer {
   text-align: center;
   padding: 1rem 0;
   background: rgba(0,0,0,0.6);
+}
+
+/* 7) Widgets on the home page */
+.widgets {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-around;
+  margin-top: 2rem;
+}
+.widget {
+  background: rgba(255,255,255,0.1);
+  padding: 2rem;
+  border-radius: 8px;
+  flex: 1;
+  text-align: center;
+  transition: transform 0.3s, box-shadow 0.3s;
+  cursor: pointer;
+}
+.widget a {
+  color: #9cf;
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+.widget:hover {
+  box-shadow: 0 8px 20px rgba(0,0,0,0.3);
 }

--- a/assets/js/widgets.js
+++ b/assets/js/widgets.js
@@ -1,0 +1,12 @@
+const widgets = document.querySelectorAll('.widget');
+widgets.forEach(widget => {
+  widget.addEventListener('mousemove', e => {
+    const rect = widget.getBoundingClientRect();
+    const x = e.clientX - rect.left - rect.width / 2;
+    const y = e.clientY - rect.top - rect.height / 2;
+    widget.style.transform = `rotateX(${(-y / 20)}deg) rotateY(${x / 20}deg)`;
+  });
+  widget.addEventListener('mouseleave', () => {
+    widget.style.transform = 'rotateX(0) rotateY(0)';
+  });
+});

--- a/index.html
+++ b/index.html
@@ -32,4 +32,10 @@ title: Home
       {% endif %}
     </ul>
   </section>
+
+  <section class="widgets">
+    <div class="widget"><a href="{{ '/blog/' | relative_url }}">Go to Blog →</a></div>
+    <div class="widget"><a href="{{ '/projects/' | relative_url }}">View Projects →</a></div>
+    <div class="widget"><a href="{{ '/about/' | relative_url }}">About Me →</a></div>
+  </section>
 </div>


### PR DESCRIPTION
## Summary
- load Google Inter font in the default layout
- update CSS to use Inter and style homepage widgets
- add widgets section on the homepage
- create a small JS for hover tilt effect

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6846cb3c8c308321a2db50d8ed958b10