### PR TITLE
Restore swirl background effect

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>{{ page.title | default: site.title }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 </head>
 <body>
@@ -24,5 +27,6 @@
   <!-- 5) Swirl scripts -->
   <script src="https://unpkg.com/simplex-noise@2.4.0/simplex-noise.js"></script>
   <script src="{{ '/assets/js/swirl.js' | relative_url }}"></script>
+  <script src="{{ '/assets/js/widgets.js' | relative_url }}"></script>
 </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4,9 +4,9 @@ html, body {
   padding: 0;
   height: 100%;
   /* Allow the animated canvas to show through */
-  background: transparent;
+  background: #000;
   color: #fff;
-  font-family: sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 
 /* 2) Canvas: full-screen, at the very back */
@@ -26,7 +26,7 @@ canvas#canvas {
   top: 0; left: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba(0,0,0,0.3);  /* play with this alpha */
+  background: rgba(0,0,0,0.2);  /* play with this alpha */
   z-index: -1;
   pointer-events: none;          /* let clicks through */
 }
@@ -64,4 +64,30 @@ footer {
   text-align: center;
   padding: 1rem 0;
   background: rgba(0,0,0,0.6);
+}
+
+/* 7) Widgets on the home page */
+.widgets {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-around;
+  margin-top: 2rem;
+}
+.widget {
+  background: rgba(255,255,255,0.1);
+  padding: 2rem;
+  border-radius: 8px;
+  flex: 1;
+  text-align: center;
+  transition: transform 0.3s, box-shadow 0.3s;
+  cursor: pointer;
+}
+.widget a {
+  color: #9cf;
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+.widget:hover {
+  box-shadow: 0 8px 20px rgba(0,0,0,0.3);
 }

--- a/assets/js/swirl.js
+++ b/assets/js/swirl.js
@@ -14,9 +14,9 @@
   const particles = Array.from({ length: 400 }, () => ({ x: Math.random() * w, y: Math.random() * h }));
 
   function animate() {
-    // Clear with transparency instead of a dark overlay so the
-    // underlying page shows through.
-    ctx.clearRect(0, 0, w, h);
+    // Darken slightly each frame for long trailing swirls
+    ctx.fillStyle = 'rgba(0,0,0,0.05)';
+    ctx.fillRect(0, 0, w, h);
 
     ctx.fillStyle = '#fff';
     particles.forEach(p => {

--- a/assets/js/widgets.js
+++ b/assets/js/widgets.js
@@ -1,0 +1,12 @@
+const widgets = document.querySelectorAll('.widget');
+widgets.forEach(widget => {
+  widget.addEventListener('mousemove', e => {
+    const rect = widget.getBoundingClientRect();
+    const x = e.clientX - rect.left - rect.width / 2;
+    const y = e.clientY - rect.top - rect.height / 2;
+    widget.style.transform = `rotateX(${(-y / 20)}deg) rotateY(${x / 20}deg)`;
+  });
+  widget.addEventListener('mouseleave', () => {
+    widget.style.transform = 'rotateX(0) rotateY(0)';
+  });
+});

--- a/index.html
+++ b/index.html
@@ -32,4 +32,10 @@ title: Home
       {% endif %}
     </ul>
   </section>
+
+  <section class="widgets">
+    <div class="widget"><a href="{{ '/blog/' | relative_url }}">Go to Blog →</a></div>
+    <div class="widget"><a href="{{ '/projects/' | relative_url }}">View Projects →</a></div>
+    <div class="widget"><a href="{{ '/about/' | relative_url }}">About Me →</a></div>
+  </section>
 </div>


### PR DESCRIPTION
## Summary
- restore black fading effect in `swirl.js`
- set page background to black for a darker look
- keep Inter font and widget features

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6846cb3c8c308321a2db50d8ed958b10