### PR TITLE
Improve swirl visibility across pages

### DIFF
--- a/_site/assets/css/main.css
+++ b/_site/assets/css/main.css
@@ -1,10 +1,14 @@
 /* Reset & swirly background */
-html, body { margin:0; padding:0; height:100%; background:#000; color:#eee; }
-canvas#canvas { position: fixed; top:0; left:0; width:100vw; height:100vh; z-index:-1; }
+html, body { margin:0; padding:0; height:100%; background:#000; color:#fff; font-family:'Inter', sans-serif; }
+canvas#canvas { position: fixed; top:0; left:0; width:100vw; height:100vh; z-index:-2; display:block; }
 
-/* Content styling */
-.page-content { position: relative; z-index:1; max-width:700px; margin:0 auto; padding:2rem; font-family:sans-serif; }
+/* Overlay tint above the swirl */
+.overlay { position:fixed; top:0; left:0; width:100vw; height:100vh; background:rgba(0,0,0,0.1); z-index:-1; pointer-events:none; }
+
+/* Header & footer with slight transparency */
+header { position:fixed; top:0; left:0; width:100%; padding:1rem; background:rgba(0,0,0,0.3); z-index:2; }
 header nav a { margin-right:1rem; color:#9cf; text-decoration:none; }
-.hero-intro p { font-size:1.2rem; }
-.latest-posts ul, .projects-preview ul { list-style:none; padding:0; }
-.latest-posts li, .projects-preview li { margin-bottom:0.5rem; }
+
+.page-content { position:relative; z-index:2; max-width:800px; margin:5rem auto 2rem; padding:2rem; background:transparent; border-radius:4px; }
+
+footer { position:relative; z-index:2; text-align:center; padding:1rem 0; background:rgba(0,0,0,0.3); }

--- a/_site/assets/js/swirl.js
+++ b/_site/assets/js/swirl.js
@@ -14,7 +14,7 @@
   const particles = Array.from({ length: 400 }, () => ({ x: Math.random() * w, y: Math.random() * h }));
 
   function animate() {
-    ctx.fillStyle = 'rgba(0,0,0,0.05)';
+    ctx.fillStyle = 'rgba(0,0,0,0.03)';
     ctx.fillRect(0, 0, w, h);
 
     ctx.fillStyle = '#fff';

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -26,7 +26,7 @@ canvas#canvas {
   top: 0; left: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba(0,0,0,0.2);  /* play with this alpha */
+  background: rgba(0,0,0,0.1);  /* lighter tint so swirls show more */
   z-index: -1;
   pointer-events: none;          /* let clicks through */
 }
@@ -37,7 +37,7 @@ header {
   top: 0; left: 0;
   width: 100%;
   padding: 1rem;
-  background: rgba(0,0,0,0.6);
+  background: rgba(0,0,0,0.3); /* more see-through */
   z-index: 2;
 }
 header nav a {
@@ -63,7 +63,7 @@ footer {
   z-index: 2;
   text-align: center;
   padding: 1rem 0;
-  background: rgba(0,0,0,0.6);
+  background: rgba(0,0,0,0.3); /* more see-through */
 }
 
 /* 7) Widgets on the home page */

--- a/assets/js/swirl.js
+++ b/assets/js/swirl.js
@@ -15,7 +15,7 @@
 
   function animate() {
     // Darken slightly each frame so the trails cover the whole screen
-    ctx.fillStyle = 'rgba(0,0,0,0.1)';
+    ctx.fillStyle = 'rgba(0,0,0,0.03)'; // slower fading for longer trails
     ctx.fillRect(0, 0, w, h);
 
     ctx.fillStyle = '#fff';


### PR DESCRIPTION
## Summary
- lighten the overlay and make the header/footer semi-transparent
- extend swirl trail duration

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846d21773748321ab941931fd567c09