### PR TITLE
Improve swirl effect and responsive layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -26,7 +26,7 @@ canvas#canvas {
   top: 0; left: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba(0,0,0,0.1);  /* lighter tint so swirls show more */
+  background: transparent;       /* let swirls show fully */
   z-index: -1;
   pointer-events: none;          /* let clicks through */
 }
@@ -69,12 +69,13 @@ footer {
 /* 7) Widgets on the home page */
 .widgets {
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
-  justify-content: space-around;
+  justify-content: center;
   margin-top: 2rem;
 }
 .widget {
-  background: #fff;
+  background: transparent; /* show swirls fully through text */
   color: #000;
   padding: 2rem;
   border-radius: 8px;
@@ -92,4 +93,11 @@ footer {
 .widget:hover {
   transform: translateY(-5px) scale(1.05);
   box-shadow: 0 10px 20px rgba(0,0,0,0.4);
+}
+
+/* 8) Responsive adjustments */
+@media (max-width: 600px) {
+  .widget {
+    flex: 1 0 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- let page swirls show completely by removing overlay tint
- keep widget layout but allow wrapping for smaller screens
- make widget backgrounds transparent so swirls show through

## Testing
- `bundle exec jekyll build` *(fails: `jekyll` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846d56ed0e883218196d0a3dff242c4