### PR TITLE
Improve swirl effect and mobile widgets

### DIFF
--- a/_site/assets/js/swirl.js
+++ b/_site/assets/js/swirl.js
@@ -15,7 +15,7 @@
 
   function animate() {
     ctx.clearRect(0, 0, w, h);
-    ctx.fillStyle = 'rgba(0,0,0,0.03)';
+    ctx.fillStyle = 'rgba(0,0,0,0.02)';
     ctx.fillRect(0, 0, w, h);
 
     ctx.fillStyle = '#fff';

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -26,7 +26,7 @@ canvas#canvas {
   top: 0; left: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba(0,0,0,0.1);  /* lighter tint so swirls show more */
+  background: transparent;       /* let swirls show fully */
   z-index: -1;
   pointer-events: none;          /* let clicks through */
 }
@@ -69,13 +69,14 @@ footer {
 /* 7) Widgets on the home page */
 .widgets {
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
-  justify-content: space-around;
+  justify-content: center;
   margin-top: 2rem;
 }
 .widget {
-  background: #fff;
-  color: #000;
+  background: transparent; /* show swirls fully through text */
+  color: #fff;
   padding: 2rem;
   border-radius: 8px;
   flex: 1;
@@ -84,7 +85,7 @@ footer {
   cursor: pointer;
 }
 .widget a {
-  color: #000;
+  color: #fff;
   text-decoration: none;
   font-weight: bold;
   font-size: 1.2rem;
@@ -92,4 +93,11 @@ footer {
 .widget:hover {
   transform: translateY(-5px) scale(1.05);
   box-shadow: 0 10px 20px rgba(0,0,0,0.4);
+}
+
+/* 8) Responsive adjustments */
+@media (max-width: 600px) {
+  .widget {
+    flex: 1 0 100%;
+  }
 }

--- a/assets/js/swirl.js
+++ b/assets/js/swirl.js
@@ -16,7 +16,7 @@
   function animate() {
     // Darken slightly each frame so the trails cover the whole screen
     ctx.clearRect(0, 0, w, h);
-    ctx.fillStyle = 'rgba(0,0,0,0.03)'; // slower fading for longer trails
+    ctx.fillStyle = 'rgba(0,0,0,0.02)'; // slightly lighter for stronger effect
     ctx.fillRect(0, 0, w, h);
 
     ctx.fillStyle = '#fff';


### PR DESCRIPTION
## Summary
- keep widgets fully transparent so swirl shows through
- use white widget text for better contrast
- lighten swirl fade for stronger visibility

## Testing
- `bundle exec jekyll build` *(fails: `jekyll` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846d56ed0e883218196d0a3dff242c4