### PR TITLE
Improve swirl visibility

### DIFF
--- a/assets/js/swirl.js
+++ b/assets/js/swirl.js
@@ -14,9 +14,8 @@
   const particles = Array.from({ length: 400 }, () => ({ x: Math.random() * w, y: Math.random() * h }));
 
   function animate() {
-    // Darken slightly each frame so the trails cover the whole screen
-    ctx.clearRect(0, 0, w, h);
-    ctx.fillStyle = 'rgba(0,0,0,0.02)'; // slightly lighter for stronger effect
+    // Darken slightly each frame so the trails linger across the screen
+    ctx.fillStyle = 'rgba(0,0,0,0.05)'; // darker fade for persistent trails
     ctx.fillRect(0, 0, w, h);
 
     ctx.fillStyle = '#fff';


### PR DESCRIPTION
## Summary
- remove dark overlay to reveal swirls across the page
- darken fade in `swirl.js` for longer lasting trails

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684710b194a483218afaff3150f5f920